### PR TITLE
Fix for Welcome email crashes if no email address present #36

### DIFF
--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -63,7 +63,7 @@ class Email < ApplicationRecord
   def self.welcome_email(organisation)
     emails_sent = 0
     PatrolMember.where(organisation: organisation).map do |pm|
-      if pm.user.email?
+      if (pm.user.present? && pm.user.email.present?)
         SwapseaMailer.welcome_email(pm.user).deliver
         emails_sent += 1
       end


### PR DESCRIPTION
Also needed to check if user exists, as well as user email.