### PR TITLE
Support for Apple Silicon / arm64 platforms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,8 @@ GEM
       timeout
     newrelic_rpm (8.9.0)
     nio4r (2.5.8)
+    nokogiri (1.13.8-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
@@ -414,6 +416,7 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-21
   x86_64-linux
 


### PR DESCRIPTION
This PR adds support for booting the application on Apple Silicon chip-based Macs.

This won't impact Heroku environments or Intel-based development environments.

