### PR TITLE
User specs enhancement

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -77,11 +77,7 @@ class User < ApplicationRecord
   end
 
   def has_patrol?
-    if patrol
-      true
-    else
-      false
-    end
+    patrol.present?
   end
 
   def offers_available_for(request)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,14 +68,6 @@ class User < ApplicationRecord
     self[:default_position] || 'Member'
   end
 
-  def email_required?
-    false
-  end
-
-  def password_required?
-    false
-  end
-
   def has_position?(position)
     if patrol_member.present? && patrol_member.default_position.present?
       patrol_member.default_position.parameterize.underscore.to_sym == position

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,8 +18,8 @@ class User < ApplicationRecord
   has_many :rosters, through: :patrol
   has_many :proficiency_signups
   has_many :proficiencies, through: :proficiency_signups
-  has_many :outreach_patrols_sign_ups
-  has_many :outreach_patrols, through: :outreach_patrols_sign_ups
+  has_many :outreach_patrol_sign_ups
+  has_many :outreach_patrol, through: :outreach_patrol_sign_ups
   has_many :swaps
   has_many :notices
   has_many :notice_acknowledgements

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,10 +5,11 @@ FactoryBot.define do
   factory :user do
     email { Faker::Internet.email }
     password { 'swapsea' }
-    club.name { 'Swapsea SLSC' }
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
     gender { 'male' }
+
+    association :club, factory: :club
   end
 
   factory :member_user, parent: :user, aliases: [:member] do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,18 +1,19 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-RSpec.describe User, type: :model do
-  before do
-    @user = create(:user)
-  end
 
-  describe '#Atributes' do
-    it 'is valid with valid attributes' do
-      expect(@user).to be_valid
+RSpec.describe User, type: :model do
+  describe 'factories' do
+    it 'has a valid default factory' do
+      expect(create(:user)).to be_valid
     end
   end
 
-  describe User, 'association' do
+  describe 'associations' do
+    # Belongs to.
+    it { is_expected.to belong_to(:club) }
+
+    # Has one and has many.
     it { is_expected.to have_many(:awards) }
     it { is_expected.to have_many(:requests) }
     it { is_expected.to have_many(:offers) }
@@ -21,25 +22,76 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_many(:rosters).through(:patrol) }
     it { is_expected.to have_many(:proficiency_signups) }
     it { is_expected.to have_many(:proficiencies).through(:proficiency_signups) }
+    it { is_expected.to have_many(:outreach_patrol_sign_ups) }
+    it { is_expected.to have_many(:outreach_patrol).through(:outreach_patrol_sign_ups) }
     it { is_expected.to have_many(:swaps) }
     it { is_expected.to have_many(:notices) }
     it { is_expected.to have_many(:notice_acknowledgements) }
   end
 
-  context '::name' do
-    let(:user) { create :user, first_name: 'First', last_name: 'Last' }
+  describe 'scopes' do
+    describe 'with_club' do
+      subject { described_class.with_club(club) }
 
-    it 'returns the correct name string' do
-      expect(user.name).to eq("#{user.first_name} #{user.last_name}")
+      let(:club) { create(:club) }
+
+      before { club }
+
+      it { is_expected.to be_empty }
     end
   end
 
-  describe User do
-    let(:club) { String(name: 'organisation') }
+  describe 'instance methods' do
+    describe 'default_position' do
+      subject { user.default_position }
 
-    it 'find club by name' do
-      expect(Club).to receive(:find_by).and_return(club)
-      expect(Club.find_by(name: 'organisation')).to eq club
+      context 'when there is no default_position on the user' do
+        let(:user) { create(:user, default_position: nil) }
+
+        it { is_expected.to eq('Member') }
+      end
+
+      context 'when there is a default_position on the user' do
+        let(:user) { create(:user, default_position: 'blah') }
+
+        it { is_expected.to eq('blah') }
+      end
+    end
+
+    describe 'has_patrol?' do
+      subject { user.has_patrol? }
+
+      let(:user) { create(:user) }
+
+      context 'when the user does not have an associated patrol through patrol members' do
+        it { is_expected.to be(false) }
+      end
+
+      context 'when the user has an associated patrol through patrol members' do
+        let(:patrol) { create(:patrol) }
+
+        before do
+          create(:patrol_member, user: user, patrol: patrol)
+        end
+
+        it { is_expected.to be(true) }
+      end
+    end
+
+    describe 'name' do
+      subject { user.name }
+
+      let(:user) { create(:user) }
+
+      it { is_expected.to eq("#{user.first_name} #{user.last_name}") }
+    end
+
+    describe 'organisation' do
+      subject { user.organisation }
+
+      let(:user) { create(:user) }
+
+      it { is_expected.to eq(user.club.name) }
     end
   end
 end


### PR DESCRIPTION
This PR fleshes out specs for the User model.

Additionally, it also:
- Fixes a typo for the User `outreach_patrol` has_many association. Given this association hasn't been working, potentially we could remove it?
- Groups specs by their type to aid readability, especially as we flesh out the specs. This does violate the current set of Rubocop rules though.
- Removes a couple unused methods