### PR TITLE
Add .slugignore for Heroku

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,7 @@
+# See https://devcenter.heroku.com/articles/slug-compiler#ignoring-files-with-slugignore
+# for more about SlugIgnore.
+
+# See https://help.github.com/articles/ignoring-files for more about ignoring files.
+
+/spec
+/test


### PR DESCRIPTION
This PR introduces a `.slugignore` file, which tells Heroku not to include specific directories when building the application.

While this application doesn't have any large assets/fixtures in the spec or test directories, it's good practice to ignore them anyway. We should see some improvement in build time.

Further background can be found here:
https://devcenter.heroku.com/articles/slug-compiler#ignoring-files-with-slugignore