### PR TITLE
Deviser to use mailer layout

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,0 @@
-<p>Welcome <%= @email %>!</p>
-
-<p>You can confirm your account email through the link below:</p>
-
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, :confirmation_token => @token) %></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,127 +1,28 @@
-<!DOCTYPE html>
-
-  <head>
-    <meta charset="utf-8" />
-    <title>Swapsea - Reset Password</title>
-    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
-    <link href="http://fonts.googleapis.com/css?family=Open+Sans:300,400,600" rel="stylesheet" type="text/css">
-
-<style type="text/css">
-
-      body {
-        font-family: 'Open Sans', sans-serif;
-        font-weight: 300;
-        font-size: 14px;
-        background-color: #F2EEEC;
-        margin: 0;
-      }
-
-      a,
-      a:visited {
-        color: #CC0000;
-        text-decoration: none;
-      }
-
-      a:hover,
-      a:focus {
-        color: #990000;
-        text-decoration: none;
-      }
-
-      .container {
-        width: 640px;
-        margin-left: auto;
-        margin-right: auto;
-        -webkit-box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.175);
-            box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.175);
-      }
-
-      .title {
-        background-color: #F13E0B;
-        color: #FEFEFE;
-        width: auto;
-      }
-
-      .title img {
-        padding: 20px;
-      }
-
-      .title h2 {
-        float: right;
-        padding: 20px;
-        margin: 0;
-      }
-
-      .content {
-        background-color: #FEFEFE;
-        width: auto;
-        padding: 40px 60px 60px 60px;
-      }
-
-      .footer {
-        text-align: center;
-        width: auto;
-        font-size: 0.8em;
-        color: #AAA;
-        margin-top: 20px;
-        margin-bottom: 40px;
-      }
-
-      @media only screen and (max-width: 640px) {
-        body {
-          background-color: #FEFEFE;
-        }
-        .title {
-          text-align: center !important;
-          width: auto;
-        }
-        .title h2 {
-          padding-top: 0;
-          float: none;
-        }
-        .container {
-          width: 100% !important;
-          -webkit-box-shadow: none;
-          box-shadow: none;
-        }
-        .content {
-          padding: 20px;
-        }
-      }
-
-      </style>
-  </head>
-  <body>
-    <div class="container">
-      <div class="title">
-        <%= image_tag('swapsea-logo-col-wht.png', width: "90%", alt: "Swapsea", class: "logo") %>
-        <h2>Choose a Password</h2>
-      </div>
-      <div class="content">
-        <p>
-          G'day <%= @resource.first_name if !@resource.has_multiple_emails? %>,
-        </p>
-        <p>
-          Almost there!
-        </p>
-        <p>
-			    Please <%= link_to 'choose a password', edit_password_url(@resource, :reset_password_token => @token) %> for Swapsea.
-		</p>
-		<p>If you don't want reset your password, please ignore this email.</p>
-  	<p>
-			<strong>'Invalid Token' error</strong><br/>
-			The link above expires after 24 hours. If you are getting an 'Invalid Token' error, please try password reset again.
-		</p>
-		<p>
-    <strong>What is Swapsea?</strong><br/>
-          Swapsea is an online swap system for Surf Life Saving Clubs that allows you to swap your patrols with other club members. Swapsea will also remind you of upcoming patrols so you don't forget. Simply login and view your roster on the dashboard.
-        </p>
-		<p>Much love,<br/>
-		Swapsea</p>
-      </div>
-    </div>
-    <div class="footer">This email was sent to <%= @resource.email %> after a request from www.swapsea.com.au. If you received this message in error, please contact <%= @user.club.name %>, or help@swapsea.com.au.<br/>
-      &copy; <%= Date.current.year %> Swapsea <br/>
-    </div>
-  </body>
-</html>
+<p>
+  G'day <%= @user.first_name %>,
+</p>
+<p>
+  Almost there!
+</p>
+<p>
+  <%= link_to 'Choose a password' , edit_password_url(@resource, :reset_password_token=> @token) %> for Swapsea.
+</p>
+<p>If you don't want to reset your password, please ignore this email.</p>
+<p>
+  <strong>'Invalid Token' error</strong><br />
+  The link above expires after 24 hours. If you are getting an 'Invalid Token' error, please <%=
+    link_to 'try password reset again' , activate_url %>.
+</p>
+<p>
+  <strong>What is Swapsea?</strong><br />
+  Swapsea is an online swap system for Surf Life Saving Clubs that allows you to swap your patrols with other club
+  members. Swapsea will also remind you of upcoming patrols so you don't forget. Simply login and view your roster on
+  the dashboard.
+</p>
+<p>
+  Have a great weekend!
+</p>
+<p>
+  Much Love,<br />
+  Swapsea
+</p>

--- a/app/views/devise/mailer/reset_password_instructions.text.erb
+++ b/app/views/devise/mailer/reset_password_instructions.text.erb
@@ -1,0 +1,25 @@
+G'day <%= @user.first_name %>,
+
+Almost there!
+
+Choose a password for Swapsea at:
+<%= edit_password_url(@resource, :reset_password_token=> @token) %>
+
+If you don't want to reset your password, please ignore this email.
+
+
+'Invalid Token' error
+---------------------
+The link above expires after 24 hours. If you are getting an 'Invalid Token' error, please try password reset again: <%= activate_url %>.
+
+
+What is Swapsea?
+----------------
+Swapsea is an online swap system for Surf Life Saving Clubs that allows you to swap your patrols with other club
+members. Swapsea will also remind you of upcoming patrols so you don't forget. Simply login and view your roster on
+the dashboard.
+
+Have a great weekend!
+
+Much Love,
+Swapsea

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,7 +1,0 @@
-<p>Hello <%= @resource.email %>!</p>
-
-<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
-
-<p>Click the link below to unlock your account:</p>
-
-<p><%= link_to 'Unlock my account', unlock_url(@resource, :unlock_token => @token) %></p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,5 +25,10 @@ module Swapsea
 
     # Custom exceptions
     config.exceptions_app = routes
+
+    config.to_prepare do
+      # Configure mailer layout for Devise same as rest of app
+      Devise::Mailer.layout 'mailer'
+    end
   end
 end


### PR DESCRIPTION
Use the standard mailer for Devise emails (reset password)
- Added text version of welcome email (may help spam filters)
- Consistent language
- Removed unused templates

Closes #174 