### PR TITLE
After sign in redirect to switch_user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,7 +26,11 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(_resource)
-    dashboard_path
+    if current_user.email_exists_on_multiple_users?
+      switch_user_path
+    else
+      dashboard_path
+    end
   end
 
   def after_sign_out_path_for(_resource_or_scope)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,6 +55,10 @@ class User < ApplicationRecord
     "#{first_name} #{last_name}"
   end
 
+def email_exists_on_multiple_users?
+  User.where(email:).count > 1
+end
+
   # Legacy use in CanCanCan (ability.rb)
   def organisation
     club.name

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -58,6 +58,29 @@ RSpec.describe User, type: :model do
       end
     end
 
+    describe 'email_exists_on_multiple_users?' do
+      subject { user.email_exists_on_multiple_users? }
+
+      let(:email) { Faker::Internet.email }
+      let(:user) { create(:user, email: email) }
+      let(:user_two) { create(:user, email: email) }
+
+      context 'when there is only one user with the email address' do
+        before { user }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context 'when there are multiple users with the email address' do
+        before do
+          user
+          user_two
+        end
+
+        it { is_expected.to be_truthy }
+      end
+    end
+
     describe 'has_patrol?' do
       subject { user.has_patrol? }
 


### PR DESCRIPTION
This PR adds support for redirecting to the `switch_user_path` when the `current_user` email exists on more than one user.

Solves #154.

This has been manually tested in development. We may want to add specs for the Device sessions controller.