### PR TITLE
Add a Content Security Policy (CSP)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
 		<%= stylesheet_link_tag "application", :media => "all" %>
 		<%= render 'application/favicon' %>
 		<%= csrf_meta_tags %>
+		<%= csp_meta_tag %>
 	</head>
 	<body>
 		<%= yield %>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# config/initializers/content_security_policy.rb
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src :self, :https
+  policy.font_src    :self, :https, :data
+  policy.img_src     :self, :https, :data
+  policy.object_src  :none
+  policy.script_src  :self, 'unsafe-inline', 'https://forecast.io', 'https://www.google-analytics.com'
+  policy.style_src   :self, 'unsafe-inline'
+end
+
+# Rails.application.config.content_security_policy_nonce_generator = -> request { request.session.id.to_s }


### PR DESCRIPTION
Simple CSP added. Already blocks a GA script loaded by the weather widget.